### PR TITLE
Fix technically wrong equation in Lucas Example. Fix filepath.

### DIFF
--- a/programs/matlab/lucas_tree_model/analytical.m
+++ b/programs/matlab/lucas_tree_model/analytical.m
@@ -174,8 +174,8 @@ end
 for j=2:NCOUNTRIES
     s=num2str(j);
     nf = nf+1;
-    f = (beta*muc(exp(c_1_p))*exp(Rs_p) - muc(exp(c_1))) ...
-        - (beta*muc(exp(eval(['c_',s,'_p'])))*exp(Rs_p) - muc(exp(eval(['c_',s]))));
+    f = (beta*muc(exp(c_1_p))*exp(Rs_p) / muc(exp(c_1))) ...
+        - (beta*muc(exp(eval(['c_',s,'_p'])))*exp(Rs_p) / muc(exp(eval(['c_',s]))));
     FF = [FF,f];
     indsF.(['ee_1',s]) = nf;
 end

--- a/programs/matlab/lucas_tree_model/lucas_trees.m
+++ b/programs/matlab/lucas_tree_model/lucas_trees.m
@@ -5,7 +5,7 @@ fprintf(['Three-country Lucas tree example model\n\n']);
 NCOUNTRIES=7;
 TINY=1.0e-9;
 addpath '../usg_toolkit';
-addpath '../devereux-sutherland-example';
+addpath '../devereux_sutherland_example';
 
 fprintf(['Declaring symbolic variables and constructing analytical ' ...
          'representation of equilibrium conditions\n']);


### PR DESCRIPTION
Hello Professor Steinberg,

I've recently started looking into using the methods developed by Devereux and Sutherland for deriving portfolio shares, and this repo has been very helpful in learning more about the methods! As I was going through the Lucas tree example, I noticed two small bugs. They don't change the portfolio shares calculated; I still get a home share of -1.571429 and foreign share of 0.428571. However, I figured it'd be best in case someone else ever comes along and wants to use this code to have the small bugs fixed.

1. The filepath being added in lucas_trees.m needs to be changed (should be `addpath ../devereux_sutherland_example`)

2. The combined Euler equations in analytical.m use a minus instead of divide when calculating the stochastic discount factors (see the changes I made).